### PR TITLE
Removed CssProvider reference to unavailable interface

### DIFF
--- a/gtk/Gtk.metadata
+++ b/gtk/Gtk.metadata
@@ -826,8 +826,6 @@
   <add-node path="/api/namespace/object[@cname='GtkWidget']"><custom-attribute>[GLib.TypeInitializer (typeof (Gtk.Widget), "ClassInit")]</custom-attribute></add-node>
   <attr path="/api/namespace/object[@cname='GtkWidget']/constructor[@cname='gtk_widget_new']" name="hidden">1</attr>
   <attr path="/api/namespace/object[@cname='GtkWidget']/method[@name='ClassFindStyleProperty']" name="hidden">1</attr>
-  <attr path="/api/namespace/object[@cname='GtkWidget']/method[@name='ClassInstallStylePropertyParser']" name="hidden">1</attr>
-  <attr path="/api/namespace/object[@cname='GtkWidget']/method[@name='ClassInstallStyleProperty']" name="hidden">1</attr>
   <attr path="/api/namespace/object[@cname='GtkWidget']/method[@name='ClassListStyleProperties']" name="hidden">1</attr>
   <attr path="/api/namespace/object[@cname='GtkWidget']/method[@name='ClassPath']/*/*[@type='gchar**']" name="pass_as">out</attr>
   <attr path="/api/namespace/object[@cname='GtkWidget']/method[@name='CreatePangoLayout']/return-type" name="owned">true</attr>

--- a/gtk/gtk-api.raw
+++ b/gtk/gtk-api.raw
@@ -9520,7 +9520,6 @@
       </virtual_method>
       <implements>
         <interface cname="GtkStyleProvider" />
-        <interface cname="GtkStyleProviderPrivate" />
       </implements>
       <method name="ErrorQuark" cname="gtk_css_provider_error_quark" shared="true">
         <return-type type="GQuark" />
@@ -16242,7 +16241,6 @@
       </virtual_method>
       <implements>
         <interface cname="GtkStyleProvider" />
-        <interface cname="GtkStyleProviderPrivate" />
       </implements>
     </object>
     <object name="MountOperation" cname="GtkMountOperation" parent="GMountOperation">
@@ -20238,7 +20236,6 @@
       </virtual_method>
       <implements>
         <interface cname="GtkStyleProvider" />
-        <interface cname="GtkStyleProviderPrivate" />
       </implements>
       <method name="GetDefault" cname="gtk_settings_get_default" shared="true">
         <return-type type="GtkSettings*" />
@@ -21970,7 +21967,6 @@
       </virtual_method>
       <implements>
         <interface cname="GtkStyleProvider" />
-        <interface cname="GtkStyleProviderPrivate" />
       </implements>
       <method name="Clear" cname="gtk_style_properties_clear">
         <return-type type="void" />


### PR DESCRIPTION
Removed CssProvider reference to unavailable interface GtkStyleProviderPrivate, so CssProvider now available for use from .Net code.

Thank you for actualized binding!
