### PR TITLE
gtk: Fix return types for null_term_array* methods in AboutDialog

### DIFF
--- a/gtk/Gtk.metadata
+++ b/gtk/Gtk.metadata
@@ -207,12 +207,12 @@
   <attr path="/api/namespace/interface[@cname='GtkTreeSortable']/method[@name='SortColumnChanged']" name="name">ChangeSortColumn</attr>
   <attr path="/api/namespace/object/implements/interface[@cname='GtkBuildable']" name="hidden">1</attr>
   <attr path="/api/namespace/object[@cname='GtkAccelLabel']/constructor[@cname='gtk_accel_label_new']/*/*[@name='string']" name="property_name">label</attr>
-  <attr path="/api/namespace/object[@cname='GtkAboutDialog']/method[@name='GetArtists']" name="hidden">1</attr>
-  <attr path="/api/namespace/object[@cname='GtkAboutDialog']/method[@name='GetAuthors']" name="hidden">1</attr>
-  <attr path="/api/namespace/object[@cname='GtkAboutDialog']/method[@name='GetDocumenters']" name="hidden">1</attr>
-  <attr path="/api/namespace/object[@cname='GtkAboutDialog']/method[@name='SetArtists']" name="hidden">1</attr>
-  <attr path="/api/namespace/object[@cname='GtkAboutDialog']/method[@name='SetAuthors']" name="hidden">1</attr>
-  <attr path="/api/namespace/object[@cname='GtkAboutDialog']/method[@name='SetDocumenters']" name="hidden">1</attr>
+  <attr path="/api/namespace/object[@cname='GtkAboutDialog']/method[@name='GetArtists']/return-type" name="null_term_array">1</attr>
+  <attr path="/api/namespace/object[@cname='GtkAboutDialog']/method[@name='GetAuthors']/return-type" name="null_term_array">1</attr>
+  <attr path="/api/namespace/object[@cname='GtkAboutDialog']/method[@name='GetDocumenters']/return-type" name="null_term_array">1</attr>
+  <attr path="/api/namespace/object[@cname='GtkAboutDialog']/method[@name='SetArtists']/*/*[@name='artists']" name="null_term_array">1</attr>
+  <attr path="/api/namespace/object[@cname='GtkAboutDialog']/method[@name='SetAuthors']/*/*[@name='authors']" name="null_term_array">1</attr>
+  <attr path="/api/namespace/object[@cname='GtkAboutDialog']/method[@name='SetDocumenters']/*/*[@name='documenters']" name="null_term_array">1</attr>
   <attr path="/api/namespace/object[@cname='GtkAction']/signal[@name='Activate']" name="name">Activated</attr>
   <attr path="/api/namespace/object[@cname='GtkAction']/method[@name='GetAccelClosure']" name="hidden">1</attr>
   <attr path="/api/namespace/object[@cname='GtkAction']/method[@name='GetProxies']" name="hidden">1</attr>


### PR DESCRIPTION
this corrects the properties Authors, Artists and Documenters
