### PR TITLE
Fixed memory leak when calling Application.Invoke and GLibSynchronizationContext from non GUI thread

### DIFF
--- a/glib/Idle.cs
+++ b/glib/Idle.cs
@@ -51,7 +51,12 @@ namespace GLib {
 
 					bool cont = idle_handler ();
 					if (!cont)
-						Remove ();
+					{
+						lock (this)
+						{
+							Remove ();
+						}
+					}
 					return cont;
 				} catch (Exception e) {
 					ExceptionManager.RaiseUnhandledException (e, false);
@@ -70,8 +75,11 @@ namespace GLib {
 		public static uint Add (IdleHandler hndlr)
 		{
 			IdleProxy p = new IdleProxy (hndlr);
-			p.ID = g_idle_add ((IdleHandlerInternal) p.proxy_handler, IntPtr.Zero);
-			Source.AddSourceHandler (p.ID, p);
+			lock (p)
+			{
+				p.ID = g_idle_add ((IdleHandlerInternal) p.proxy_handler, IntPtr.Zero);
+				Source.AddSourceHandler (p.ID, p);
+			}
 
 			return p.ID;
 		}
@@ -82,8 +90,11 @@ namespace GLib {
 		public static uint Add (IdleHandler hndlr, Priority priority)
 		{
 			IdleProxy p = new IdleProxy (hndlr);
-			p.ID = g_idle_add_full ((int)priority, (IdleHandlerInternal)p.proxy_handler, IntPtr.Zero, null);
-			Source.AddSourceHandler (p.ID, p);
+			lock (p)
+			{
+				p.ID = g_idle_add_full ((int)priority, (IdleHandlerInternal)p.proxy_handler, IntPtr.Zero, null);
+				Source.AddSourceHandler (p.ID, p);
+			}
 
 			return p.ID;
 		}

--- a/glib/Timeout.cs
+++ b/glib/Timeout.cs
@@ -49,7 +49,12 @@ namespace GLib {
 
 					bool cont = timeout_handler ();
 					if (!cont)
-						Remove ();
+					{
+						lock (this)
+						{
+							Remove ();
+						}
+					}
 					return cont;
 				} catch (Exception e) {
 					ExceptionManager.RaiseUnhandledException (e, false);
@@ -65,9 +70,11 @@ namespace GLib {
 		public static uint Add (uint interval, TimeoutHandler hndlr)
 		{
 			TimeoutProxy p = new TimeoutProxy (hndlr);
-
-			p.ID = g_timeout_add (interval, (TimeoutHandlerInternal) p.proxy_handler, IntPtr.Zero);
-			Source.AddSourceHandler (p.ID, p);
+			lock (p)
+			{
+				p.ID = g_timeout_add (interval, (TimeoutHandlerInternal) p.proxy_handler, IntPtr.Zero);
+				Source.AddSourceHandler (p.ID, p);
+			}
 
 			return p.ID;
 		}
@@ -78,9 +85,11 @@ namespace GLib {
 		public static uint Add (uint interval, TimeoutHandler hndlr, Priority priority)
 		{
 			TimeoutProxy p = new TimeoutProxy (hndlr);
-
-			p.ID = g_timeout_add_full ((int)priority, interval, (TimeoutHandlerInternal) p.proxy_handler, IntPtr.Zero, null);
-			Source.AddSourceHandler (p.ID, p);
+			lock (p)
+			{
+				p.ID = g_timeout_add_full ((int)priority, interval, (TimeoutHandlerInternal) p.proxy_handler, IntPtr.Zero, null);
+				Source.AddSourceHandler (p.ID, p);
+			}
 
 			return p.ID;
 		}
@@ -91,9 +100,11 @@ namespace GLib {
 		public static uint AddSeconds (uint interval, TimeoutHandler hndlr)
 		{
 			TimeoutProxy p = new TimeoutProxy (hndlr);
-
-			p.ID = g_timeout_add_seconds (interval, (TimeoutHandlerInternal) p.proxy_handler, IntPtr.Zero);
-			Source.AddSourceHandler (p.ID, p);
+			lock (p)
+			{
+				p.ID = g_timeout_add_seconds (interval, (TimeoutHandlerInternal) p.proxy_handler, IntPtr.Zero);
+				Source.AddSourceHandler (p.ID, p);
+			}
 
 			return p.ID;
 		}


### PR DESCRIPTION
Fixed memory leak when calling Application.Invoke(uses Timeout.Add) and GLibSynchronizationContext(uses Idle.Add) from non GUI thread.
https://bugzilla.xamarin.com/show_bug.cgi?id=21900
