### PR TITLE
Small change to allow for building against latest gtk3

### DIFF
--- a/gtk/Plug.cs
+++ b/gtk/Plug.cs
@@ -33,7 +33,7 @@ namespace Gtk {
 		{
 			if (GetType () != typeof (Plug)) {
 				CreateNativeObject (new string [0], new GLib.Value [0]);
-				Construct (socket_id);
+				Construct (Convert.ToUInt32(socket_id));
 				return;
 			}
 			Raw = gtk_plug_new (new UIntPtr (socket_id));
@@ -46,7 +46,7 @@ namespace Gtk {
 		{
 			if (GetType () != typeof (Plug)) {
 				CreateNativeObject (new string [0], new GLib.Value [0]);
-				ConstructForDisplay (display, socket_id);
+				ConstructForDisplay (display, Convert.ToUInt32(socket_id));
 				return;
 			}
 			Raw = gtk_plug_new_for_display (display.Handle, new UIntPtr (socket_id));


### PR DESCRIPTION
I've found with the latest source, that this small change is just needed to allow building of the .Net libs

I've put some details on my blog on how I've been running the build
http://grbd.github.io/posts/2016/06/30/building-gtk3-gtksharp-under-windows-manual-build/
