### PR TITLE
Fix System.Array usage in {List,Tree}Store

### DIFF
--- a/gtk/ArrayExtensions.cs
+++ b/gtk/ArrayExtensions.cs
@@ -1,0 +1,35 @@
+// Gtk.TreeStore.cs - Gtk TreeStore class customizations
+//
+// Authors: Marek Habersack <grendel@twistedcode.net>
+//
+// Copyright (c) 2016 Marek Habersack
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of version 2 of the Lesser GNU General 
+// Public License as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this program; if not, write to the
+// Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+// Boston, MA 02111-1307, USA.
+
+namespace Gtk {
+	using System;
+
+	static class ArrayExtensions
+	{
+		public static object[] Explode (this Array arr)
+		{
+			if (arr == null)
+				return null;
+			var ret = new object [arr.Length];
+			arr.CopyTo (ret, 0);
+			return ret;
+		}
+	}
+}

--- a/gtk/ListStore.cs
+++ b/gtk/ListStore.cs
@@ -110,7 +110,7 @@ namespace Gtk {
 		public Gtk.TreeIter AppendValues (Array values) 
 		{
 			Gtk.TreeIter iter = Append();
-			SetValues (iter, values);
+			SetValues (iter, values.Explode ());
 			return iter;
 		}
 		

--- a/gtk/Makefile.am
+++ b/gtk/Makefile.am
@@ -22,6 +22,7 @@ sources = 				\
 	ActionGroup.cs		\
 	Adjustment.cs			\
 	Application.cs			\
+	ArrayExtensions.cs	\
 	Bin.cs				\
 	BindingAttribute.cs		\
 	Builder.cs			\

--- a/gtk/TreeStore.cs
+++ b/gtk/TreeStore.cs
@@ -200,7 +200,7 @@ namespace Gtk {
 
 		public Gtk.TreeIter AppendValues (Gtk.TreeIter parent, Array values) {
 			Gtk.TreeIter iter = AppendNode (parent);
-			SetValues (iter, values);
+			SetValues (iter, values.Explode ());
 			return iter;
 		}
 		
@@ -212,12 +212,14 @@ namespace Gtk {
 
 		public Gtk.TreeIter AppendValues (Array values) {
 			Gtk.TreeIter iter = AppendNode ();
-			SetValues (iter, values);
+			SetValues (iter, values.Explode ());
 			return iter;
 		}
 		
 		public Gtk.TreeIter AppendValues (params object[] values) {
-			return AppendValues ((Array) values);
+			Gtk.TreeIter iter = AppendNode ();
+			SetValues (iter, values);
+			return iter;
 		}
 
 		[DllImport (Global.GtkNativeDll, CallingConvention = CallingConvention.Cdecl)]

--- a/gtk/gtk.csproj
+++ b/gtk/gtk.csproj
@@ -141,6 +141,7 @@
     <Compile Include="Widget.cs" />
     <Compile Include="Window.cs" />
     <Compile Include="RadioAction.cs" />
+    <Compile Include="ArrayExtensions.cs" />
     <Compile Include="generated\Gtk\AboutDialog.cs" />
     <Compile Include="generated\Gtk\Accel.cs" />
     <Compile Include="generated\Gtk\AccelActivateHandler.cs" />


### PR DESCRIPTION
{List,Tree}Store.AppendValues overloads which take System.Array as their
'values' parameter incorrectly pass the array down to SetValues. The latter
expects a 'params object[]' array of parameters but passing an instance of
System.Array to such method will NOT pass the contents of System.Array instance
into the 'params' method as separate members of the parms array. It will instead
box System.Array and the params method will receive one parameter of type
System.Array instead of X parameters of various types. This affects the
following example code:

   var store = new TreeStore (typeof (string), typeof (int));
   store.AppendValues ("One", 1);

If the column configured to retrieve the 'string' value reads data from this
store it will instead get an instance of System.Array and the node displayed by
the TreeView will have no text, won't be clickable etc.

The fix implemented here is to "explode" the System.Array into a separate array
of the 'object[]' type.

The 'TreeStore.AppendValues (params object[] values)' overload no longer calls
the 'TreeStore.Appendvalues (Array values)' overload since the indirection only
wastes time and memory. It now directly calls `SetValues`.