### PR TITLE
Fix the ActionMap.AddActionEntries API

### DIFF
--- a/gio/gio-api.raw
+++ b/gio/gio-api.raw
@@ -1048,7 +1048,7 @@
       <method name="AddActionEntries" cname="g_action_map_add_action_entries">
         <return-type type="void" />
         <parameters>
-          <parameter type="const-GActionEntry*" name="entries" />
+          <parameter type="const-GActionEntry*" name="entries" array="true" />
           <parameter type="gint" name="n_entries" />
           <parameter type="gpointer" name="user_data" />
         </parameters>


### PR DESCRIPTION
The 'entries' parameter is an array.