### PR TITLE
Bind a number of Gtk.CellRendererTextProperties

### DIFF
--- a/gtk/gtk-api.raw
+++ b/gtk/gtk-api.raw
@@ -8114,30 +8114,46 @@
       <property name="Background" cname="background" type="gchar*" writeable="true" />
       <property name="BackgroundGdk" cname="background-gdk" type="GdkColor" readable="true" writeable="true" />
       <property name="BackgroundRgba" cname="background-rgba" type="GdkRgba" readable="true" writeable="true" />
+      <property name="BackgroundSet" cname="background-set" type="gboolean" readable="true" writeable="true" />
       <property name="Foreground" cname="foreground" type="gchar*" writeable="true" />
       <property name="ForegroundGdk" cname="foreground-gdk" type="GdkColor" readable="true" writeable="true" />
       <property name="ForegroundRgba" cname="foreground-rgba" type="GdkRgba" readable="true" writeable="true" />
+      <property name="ForegroundSet" cname="foreground-set" type="gboolean" readable="true" writeable="true" />
       <property name="Editable" cname="editable" type="gboolean" readable="true" writeable="true" />
+      <property name="EditableSet" cname="editable-set" type="gboolean" readable="true" writeable="true" />
       <property name="Font" cname="font" type="gchar*" readable="true" writeable="true" />
       <property name="FontDesc" cname="font-desc" type="PangoFontDescription" readable="true" writeable="true" />
       <property name="Family" cname="family" type="gchar*" readable="true" writeable="true" />
+      <property name="FamilySet" cname="family-set" type="gboolean" readable="true" writeable="true" />
       <property name="Style" cname="style" type="PangoStyle" readable="true" writeable="true" />
+      <property name="StyleSet" cname="style-set" type="gboolean" readable="true" writeable="true" />
       <property name="Variant" cname="variant" type="PangoVariant" readable="true" writeable="true" />
+      <property name="VariantSet" cname="variant-set" type="gboolean" readable="true" writeable="true" />
       <property name="Weight" cname="weight" type="gint" readable="true" writeable="true" />
+      <property name="WeightSet" cname="weight-set" type="gboolean" readable="true" writeable="true" />
       <property name="Stretch" cname="stretch" type="PangoStretch" readable="true" writeable="true" />
+      <property name="StretchSet" cname="stretch-set" type="gboolean" readable="true" writeable="true" />
       <property name="Size" cname="size" type="gint" readable="true" writeable="true" />
+      <property name="SizeSet" cname="size-set" type="gboolean" readable="true" writeable="true" />
       <property name="SizePoints" cname="size-points" type="gdouble" readable="true" writeable="true" />
       <property name="Scale" cname="scale" type="gdouble" readable="true" writeable="true" />
+      <property name="ScaleSet" cname="scale-set" type="gboolean" readable="true" writeable="true" />
       <property name="Rise" cname="rise" type="gint" readable="true" writeable="true" />
+      <property name="RiseSet" cname="rise-set" type="gboolean" readable="true" writeable="true" />
       <property name="Strikethrough" cname="strikethrough" type="gboolean" readable="true" writeable="true" />
+      <property name="StrikethroughSet" cname="strikethrough-set" type="gboolean" readable="true" writeable="true" />
       <property name="Underline" cname="underline" type="PangoUnderline" readable="true" writeable="true" />
+      <property name="UnderlineSet" cname="underline-set" type="gboolean" readable="true" writeable="true" />
       <property name="Language" cname="language" type="gchar*" readable="true" writeable="true" />
+      <property name="LanguageSet" cname="language-set" type="gboolean" readable="true" writeable="true" />
       <property name="Ellipsize" cname="ellipsize" type="PangoEllipsizeMode" readable="true" writeable="true" />
+      <property name="EllipsizeSet" cname="ellipsize-set" type="gboolean" readable="true" writeable="true" />
       <property name="WidthChars" cname="width-chars" type="gint" readable="true" writeable="true" />
       <property name="MaxWidthChars" cname="max-width-chars" type="gint" readable="true" writeable="true" />
       <property name="WrapMode" cname="wrap-mode" type="PangoWrapMode" readable="true" writeable="true" />
       <property name="WrapWidth" cname="wrap-width" type="gint" readable="true" writeable="true" />
       <property name="Alignment" cname="alignment" type="PangoAlignment" readable="true" writeable="true" />
+      <property name="AlignmentSet" cname="align-set" type="gboolean" readable="true" writeable="true" />
       <property name="PlaceholderText" cname="placeholder-text" type="gchar*" readable="true" writeable="true" />
       <signal name="Edited" cname="edited" when="LAST" field_name="edited">
         <return-type type="void" />


### PR DESCRIPTION
This binds all the '*-set' properties. The properties are useful when one
wants to restore a previously set property to its initial value. For instance,
when setting the ForegroundRgba property the 'foreground-set' property is
automatically set to 'true' but when we assign 'Gdk.RGBA.Zero' to ForegroundRgba then the
'foreground-set' property is NOT set to false and the foreground becomes black instead
of the default one.