### PR TITLE
Include debugging symbols in nupkg

### DIFF
--- a/NuGet/pybuild/profiles/GtkSharp.py
+++ b/NuGet/pybuild/profiles/GtkSharp.py
@@ -67,5 +67,6 @@ class GtkSharp(ProfileBase):
         dll_list = ['atk', 'cairo', 'gdk', 'gio', 'glib', 'gtk', 'pango']
         for item in dll_list:
             shutil.copy(join(self.SrcDir, item, item + "-sharp.dll"), net45_lib_dir)
+            shutil.copy(join(self.SrcDir, item, item + "-sharp.pdb"), net45_lib_dir)
             if item != 'cairo':
                 shutil.copy(join(self.SrcDir, item, item + '-sharp.dll.config'), net45_build_dir)


### PR DESCRIPTION
I believe debugging symbols should be included in nupkg by default. GTK# is not very well documented and having debugging symbols could save many troubles when using it.

Size overhead is not that big, 4MB instead of 1MB.