### PR TITLE
Some fixes to support updated gstreamer-sharp

### DIFF
--- a/generator/Parameters.cs
+++ b/generator/Parameters.cs
@@ -206,7 +206,7 @@ namespace GtkSharp.Generation {
 					return false;
 				}
 
-				if (p.IsOptional && p.PassAs == String.Empty)
+				if (p.IsOptional && p.PassAs == String.Empty && p.IsUserData == false)
 					has_optional = true;
 
 				IGeneratable gen = p.Generatable;

--- a/generator/Property.cs
+++ b/generator/Property.cs
@@ -68,10 +68,14 @@ namespace GtkSharp.Generation {
 		}
 
 		protected virtual string RawGetter (string qpname) {
+            if (container_type is InterfaceGen)
+                return "implementor.GetProperty (" + qpname + ")";
 			return "GetProperty (" + qpname + ")";
 		}
 
 		protected virtual string RawSetter (string qpname) {
+            if (container_type is InterfaceGen)
+                return "implementor.SetProperty(" + qpname + ", val)";
 			return "SetProperty(" + qpname + ", val)";
 		}
 

--- a/generator/StructField.cs
+++ b/generator/StructField.cs
@@ -102,7 +102,11 @@ namespace GtkSharp.Generation {
 
 		public bool IsPadding {
 			get {
-				return (CName.StartsWith ("dummy") || CName.StartsWith ("padding"));
+				if (elem.GetAttributeAsBoolean ("is-padding"))
+					return elem.GetAttributeAsBoolean ("is-padding");
+
+				return (elem.GetAttribute ("access") == "private" && (
+					CName.StartsWith ("dummy") || CName.StartsWith ("padding")));
 			}
 		}
 


### PR DESCRIPTION
Misc fixes for `gstreamer-sharp` 1.12, includes:
  - Fix the way we check if a structure field is padding
  - Handle generating GInterface properties
  - Ignore `user data` function arguments to generate alternative methods 